### PR TITLE
Fixed writing into EEPROM memory

### DIFF
--- a/SetNodeId/SetNodeId.ino
+++ b/SetNodeId/SetNodeId.ino
@@ -1,22 +1,27 @@
 
 #include <EEPROM.h>
 
+#ifdef ESP32
 #define EEPROM_SIZE 1
-
+#endif
 // change this to be the ID of your node in the mesh network
 uint8_t nodeId = 1;
 
 void setup() {
   Serial.begin(115200);
   while (!Serial) ; // Wait for serial port to be available
+  #ifdef ESP32
   EEPROM.begin(EEPROM_SIZE); // initialize EEPROM with predefined size
+  #endif
 
   Serial.println("setting nodeId...");
 
   EEPROM.write(0, nodeId);
   Serial.print(F("set nodeId = "));
   Serial.println(nodeId);
+  #ifdef ESP32
   EEPROM.commit();
+  #endif
 
   uint8_t readVal = EEPROM.read(0);
 

--- a/SetNodeId/SetNodeId.ino
+++ b/SetNodeId/SetNodeId.ino
@@ -1,18 +1,22 @@
 
 #include <EEPROM.h>
 
+#define EEPROM_SIZE 1
+
 // change this to be the ID of your node in the mesh network
 uint8_t nodeId = 1;
 
 void setup() {
   Serial.begin(115200);
   while (!Serial) ; // Wait for serial port to be available
+  EEPROM.begin(EEPROM_SIZE); // initialize EEPROM with predefined size
 
   Serial.println("setting nodeId...");
 
   EEPROM.write(0, nodeId);
   Serial.print(F("set nodeId = "));
   Serial.println(nodeId);
+  EEPROM.commit();
 
   uint8_t readVal = EEPROM.read(0);
 


### PR DESCRIPTION
Before adding functions `EEPROM.begin(EEPROM_SIZE);` and `EEPROM.commit();`, there was problem with writing value into EEPROM memory on ESP32. With the two added functions it works well.